### PR TITLE
updated to use createRoot for render

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
-import ReactDOM from 'react-dom'
+import ReactDOM from 'react-dom/client'
 import App from './App'
 import './index.css'
 
-
-ReactDOM.render(<App/ >, document.querySelector('#root'))
+const root = ReactDOM.createRoot(
+    document.getElementById('root')
+)
+root.render(<App />);


### PR DESCRIPTION
Using the react 18 preferred createRoot() instead of ReactDOM.render().

Tested the site after update, including all links, all nav, and the contact form.